### PR TITLE
Use ruby:2.6-stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM ruby:2.6-stretch
 
 ### DockerInDocker support is take from
 ### https://github.com/jpetazzo/dind/blob/master/Dockerfile . I


### PR DESCRIPTION
The docker installation script doesn't support buster properly yet. Pin to stretch, at least until it gets updated.

This doesn't really seem like it merits a version bump or a changelog entry. The previous successful build of 1.11.1 used stretch, so this change just moves us back to where we were.