### PR TITLE
Ubuntu 14.04 to 18.04 upgrade as 14.04 is EOL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.11.1
+
+* Update Conjur Dockerfile from Ubuntu 14.04 --> 18.04 as 14.04 repos
+  are now behind a [pay wall](https://ubuntu.com/blog/ubuntu-14-04-esm-support)
+  Ruby is installed from `ppa:brightbox/ruby-ng` however that PPA
+  [doesn't currently supply ruby2.2 for Ubuntu 18.04](https://launchpad.net/~brightbox/+archive/ubuntu/ruby-ng?field.series_filter=bionic). [The documentation](https://www.brightbox.com/docs/ruby/ubuntu/)
+  suggests this combination is available, so it may be a temporary problem.
+  To work around the problem, ruby is bumped from 2.2 to 2.3 as 2.3 is the oldest
+  version available for Ubuntu 18.04.
+
 # 1.11.0
 
 * Use a Docker env-file (docker.env, by default) to pass environment

--- a/lib/conjur/fpm/Dockerfile
+++ b/lib/conjur/fpm/Dockerfile
@@ -1,15 +1,15 @@
 # Build from the same version of ubuntu as phusion/baseimage
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 RUN apt-get update -y && \
     apt-get install -y software-properties-common && \
     apt-add-repository -y ppa:brightbox/ruby-ng && \
     apt-get update -y && \
-    apt-get install -y build-essential git libpq5 libpq-dev ruby2.2 ruby2.2-dev libffi-dev
+    apt-get install -y build-essential git libpq5 libpq-dev ruby2.3 ruby2.3-dev libffi-dev
 
 
-# Configure bundler and gem the way the ruby:2.2 Dockerfile does, as of 
-# https://github.com/docker-library/ruby/commit/c88f3a67da720bfa9fb1717960d90fd5db11c757
+# Configure bundler and gem the way the ruby:2.3 Dockerfile does, as of
+# https://github.com/docker-library/ruby/blob/c88f3a67da720bfa9fb1717960d90fd5db11c757/2.3/Dockerfile#L41-L54
 ENV BUNDLER_VERSION 1.11.2
 
 RUN gem install --no-rdoc --no-ri bundler:$BUNDLER_VERSION ruby-xz:0.2.3 fpm


### PR DESCRIPTION
Ubuntu 14.04 has entered the "Extended Secuirty Maintenance" phase
which means it's repos are behind a paywall. Access can be gained via
an Ubuntu Advantage Subscription from Canonical. This commit takes
the alternate route and upgrades the base iamge to Ubuntu 18.04.

The Dockerfile installs Ruby from `ppa:brightbox/ruby-ng` however that
PPA doesn't currently supply ruby2.2 for Ubuntu
18.04[1]. The documentation[2] suggests this combination is available,
so it may be a temporary problem. To work around the problem, ruby is
bumped from 2.2 to 2.3 as 2.3 is the oldest version available for
Ubuntu 18.04.

Related: conjurinc/appliance#1067

[1] launchpad.net/~brightbox/+archive/ubuntu/ruby-ng?field.series_filter=bionic
[2] brightbox.com/docs/ruby/ubuntu