### PR TITLE
Add version constraint to gemspec for Aruba

### DIFF
--- a/debify.gemspec
+++ b/debify.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   # group is 0 instead of nil, which breaks aruba's "I successfully
   # run...." steps.
   spec.add_development_dependency "cucumber", '~> 2'
-  spec.add_development_dependency "aruba"
+  spec.add_development_dependency "aruba", "~> 0.14"
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'ci_reporter_rspec', '~> 1.0'
 end


### PR DESCRIPTION
This PR pins Aruba in the Gemfile to continue using a compatible version.

The debify tests use a deprecated Aruba method, `run_simple`. This method is removed in version `1.0.0`, so we constrain our tests to remain at version `0.14+`.

Connected to #35 