### PR TITLE
Bump rake in gemspec

### DIFF
--- a/debify.gemspec
+++ b/debify.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "fakefs", "~> 0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.3.3"
   
   # Pin to cucumbe v2. cucumber v3 changes (breaks) the behavior of
   # unmatched capture groups with \(d+). In v3, the value of such a


### PR DESCRIPTION
Fix vulernability in rake https://nvd.nist.gov/vuln/detail/CVE-2020-8130