### PR TITLE
Rails 5 build support

### DIFF
--- a/lib/conjur/fpm/Dockerfile
+++ b/lib/conjur/fpm/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update -y && \
                        libpq5 \
                        libpq-dev \
                        ruby2.5 \
-                       ruby2.5-dev
+                       ruby2.5-dev \
+                       build-essential patch ruby-dev zlib1g-dev liblzma-dev
 
 RUN gem install --no-document bundler:1.17.3 \
                               fpm


### PR DESCRIPTION
To support packaging of Conjur with Rails 5, we need to install those packages (for nokogiri).