### PR TITLE
Make builds fail on new HIGH trivy issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
             script {
               VERSION = sh(returnStdout: true, script: 'cat VERSION')
             }
-            scanAndReport("debify:${VERSION}", "CRITICAL", false)
+            scanAndReport("debify:${VERSION}", "HIGH", false)
           }
         }
         // No all report generated because it currently adds 10-12 minutes of


### PR DESCRIPTION
Future builds will fail if trivy detects any fixable HIGH severity issues. 
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>