### PR TITLE
Add apt-get upgrade command to fetch security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ FROM ruby:2.6-stretch
 ### docker:dind image much more complicated and didn't lend itself to
 ### also running ruby.
 
-RUN apt-get update -qq && apt-get install -qqy \
+RUN apt-get update -qq && \
+    apt-get dist-upgrade -qqy && \
+    apt-get install -qqy \
     apt-transport-https \
     ca-certificates \
     curl \

--- a/lib/conjur/fpm/Dockerfile
+++ b/lib/conjur/fpm/Dockerfile
@@ -2,6 +2,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get update -y && \
+    apt-get dist-upgrade -y && \
     apt-get install -y build-essential \
                        git \
                        libffi-dev \


### PR DESCRIPTION
Nightly build failed on trivy scan stage.
There are two completely new vulnerabilities there are have fixes.
`apt-get upgrade` command cares to install latest versions of updated packages and as a result allow to pass trivyscan.