### PR TITLE
Switch agent to work with rhel-ee

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 pipeline {
-  agent { label 'executor-v2' }
+  agent { label 'executor-v2-rhel-ee-large' }
 
   options {
     timestamps()


### PR DESCRIPTION
Switch repo pipeline to work with `executor-v2-rhel-ee-large` to support FIPS build and tests
"publish to rubygems" stage should stay with existing agent.