### PR TITLE
Mount the home directory and use it as HOME for docker-debify

### DIFF
--- a/distrib/docker-debify
+++ b/distrib/docker-debify
@@ -39,10 +39,12 @@ docker run -i $tty --rm \
   -e CONJUR_APPLIANCE_URL -e CONJUR_SSL_CERTIFICATE \
   -e GIT_BRANCH -e BRANCH_NAME \
   -e ARTIFACTORY_USER -e ARTIFACTORY_PASSWORD \
+  -e HOME \
   ${envfile_arg} \
-  -v $PWD:$PWD -w $PWD \
+  -v "$PWD:$PWD" -w "$PWD" \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -v ${netrc}:/root/.netrc:ro \
+  -v "${HOME}:${HOME}" \
+  -v "${netrc}:${HOME}/.netrc:ro" \
   ${rc_arg} \
   ${DEBIFY_ENTRYPOINT+--entrypoint $DEBIFY_ENTRYPOINT} \
   ${DEBIFY_IMAGE-registry.tld/conjurinc/debify:@@DEBIFY_VERSION@@} "$@"


### PR DESCRIPTION
By default, the docker-debify container uses `/root` as the home directory when creating
containers for test and sandbox environments. This fails when `/root` is not available
for mounting on the host machine, as is the case in recent docker for mac versions.

This PR changes `docker-debify` to use `$HOME` from the host in the container, as `debify` without docker would do.