### PR TITLE
Package and publish an RPM file as well as debian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ features/reports
 results.html
 mkmf.log
 *.deb
+*.rpm
 *.gem
 docker-debify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Added
+- Debify now packages and publishes an RPM file, alongside a debian file.
+  [conjurinc/debify#49](https://github.com/conjurinc/debify/pull/49)
+
 # 1.11.5
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Debify
 
+Debify is a tool used for building and testing DAP appliance packages.
+It is mainly used to package and publish debian packages that are consumed into the
+appliance image in its build stage. However, it also packages and publishes an
+RPM package whenever it does so for a debian.
+
 ## Installation
 
 There are two different ways of installing debify: as a gem, or as a Docker image.

--- a/debify.gemspec
+++ b/debify.gemspec
@@ -6,8 +6,8 @@ require 'conjur/debify/version'
 Gem::Specification.new do |spec|
   spec.name          = "conjur-debify"
   spec.version       = Conjur::Debify::VERSION
-  spec.authors       = ["Kevin Gilpin"]
-  spec.email         = ["kgilpin@conjur.net"]
+  spec.authors       = ["CyberArk Software, Inc."]
+  spec.email         = ["conj_maintainers@cyberark.com"]
   spec.summary       = %q{Utility commands to build and package Conjur services as Debian packages}
   spec.homepage      = "https://github.com/conjurinc/debify"
   spec.license       = "MIT"

--- a/features/package.feature
+++ b/features/package.feature
@@ -2,16 +2,21 @@
 Feature: Packaging
 
   Background:
-    Given I successfully run `env DEBUG=true GLI_DEBUG=true debify package -d ../../example -v 0.0.1 example -- --post-install /distrib/postinstall.sh`
+    # We use version 0.0.1-suffix to verify that RPM converts dashes to underscores
+    # in the version as we expect
+    Given I successfully run `env DEBUG=true GLI_DEBUG=true debify package -d ../../example -v 0.0.1-suffix example -- --post-install /distrib/postinstall.sh`
 
   Scenario: 'example' project can be packaged successfully
-    Then the stdout should contain "conjur-example_0.0.1_amd64.deb"
-    And the stdout should contain "conjur-example-dev_0.0.1_amd64.deb"
+    Then the stdout should contain "conjur-example_0.0.1-suffix_amd64.deb"
+    And the stdout should contain "conjur-example-dev_0.0.1-suffix_amd64.deb"
+    And the stdout should contain "conjur-example-0.0.1_suffix-1.x86_64.rpm"
+    And the stdout should contain "conjur-example-dev-0.0.1_suffix-1.x86_64.rpm"
 
   Scenario: 'clean' command will delete non-Git-managed files
     When I successfully run `env DEBUG=true GLI_DEBUG=true debify clean -d ../../example --force`
     And I successfully run `find ../../example`
-    Then the stdout from "find ../../example" should not contain "conjur-example_0.0.1_amd64.deb"
-    
+    Then the stdout from "find ../../example" should not contain "conjur-example_0.0.1-suffix_amd64.deb"
+    And the stdout from "find ../../example" should not contain "conjur-example-0.0.1_suffix-1.x86_64.rpm"
+
   Scenario: 'example' project can be published
-    When I successfully run `env DEBUG=true GLI_DEBUG=true debify publish -v 0.0.1 -d ../../example 4.9 example`
+    When I successfully run `env DEBUG=true GLI_DEBUG=true debify publish -v 0.0.1-suffix -d ../../example 4.9 example`

--- a/lib/conjur/debify.rb
+++ b/lib/conjur/debify.rb
@@ -732,6 +732,10 @@ command "publish" do |c|
   c.default_value "debian-private"
   c.flag [ :r, :repo]
 
+  c.desc "Artifactory RPM repo to publish package to"
+  c.default_value "redhat-private"
+  c.flag ['rpm-repo']
+
   c.action do |global_options,cmd_options,args|
     require 'conjur/debify/action/publish'
     raise "distribution is required" unless distribution = args.shift

--- a/lib/conjur/debify/action/publish.rb
+++ b/lib/conjur/debify/action/publish.rb
@@ -25,14 +25,12 @@ module Conjur::Debify
 
         Dir.chdir dir do
           version = cmd_options[:version] || detect_version
-          component = cmd_options[:component] || detect_component
-          package_name = "conjur-#{project_name}_#{version}_amd64.deb"
 
           publish_image = create_image
           DebugMixin.debug_write "Built base publish image '#{publish_image.id}'\n"
 
           art_url = cmd_options[:url]
-          art_repo = cmd_options[:repo]
+          deb_art_repo = cmd_options[:repo]
 
           art_user = ENV['ARTIFACTORY_USER']
           art_password = ENV['ARTIFACTORY_PASSWORD']
@@ -40,23 +38,35 @@ module Conjur::Debify
             art_user, art_password = fetch_art_creds
           end
 
-          options = {
-            'Image' => publish_image.id,
-            'Cmd' => [
-              "jfrog", "rt", "upload",
-              "--url", art_url,
-              "--user", art_user,
-              "--password", art_password,
-              "--deb", "#{distribution}/#{component}/amd64",
-              package_name, "#{art_repo}/"
-            ],
-            'Binds' => [
-              [ dir, "/src" ].join(':')
-            ]
-          }
-          options['Privileged'] = true if Docker.version['Version'] >= '1.10.0'
+          # Publish deb package
+          component = cmd_options[:component] || detect_component
+          deb_info = "#{distribution}/#{component}/amd64"
+          package_name = "conjur-#{project_name}_#{version}_amd64.deb"
+          publish_package(
+            publish_image: publish_image,
+            art_url: art_url,
+            art_user: art_user,
+            art_password: art_password,
+            art_repo: deb_art_repo,
+            package_name: package_name,
+            dir: dir,
+            deb_info: deb_info
+          )
 
-          publish(options)
+          # Publish RPM package
+          # The rpm builder replaces dashes with underscores in the version
+          rpm_version = version.tr('-', '_')
+          package_name = "conjur-#{project_name}-#{rpm_version}-1.x86_64.rpm"
+          rpm_art_repo = cmd_options['rpm-repo']
+          publish_package(
+            publish_image: publish_image,
+            art_url: art_url,
+            art_user: art_user,
+            art_password: art_password,
+            art_repo: rpm_art_repo,
+            package_name: package_name,
+            dir: dir
+          )
         end
       end
 
@@ -75,6 +85,39 @@ module Conjur::Debify
         username_var = [account, "variable", "ci/artifactory/users/jenkins/username"].join(':')
         password_var = [account, "variable", 'ci/artifactory/users/jenkins/password'].join(':')
         [conjur.resource(username_var).value, conjur.resource(password_var).value]
+      end
+
+      def publish_package(
+        publish_image:,
+        art_url:,
+        art_user:,
+        art_password:,
+        art_repo:,
+        package_name:,
+        dir:,
+        deb_info: nil
+      )
+
+        cmd_args = [
+          "jfrog", "rt", "upload",
+          "--url", art_url,
+          "--user", art_user,
+          "--password", art_password,
+        ]
+
+        cmd_args += ["--deb", deb_info] if deb_info
+        cmd_args += [package_name, "#{art_repo}/"]
+
+        options = {
+          'Image' => publish_image.id,
+          'Cmd' => cmd_args,
+          'Binds' => [
+            [ dir, "/src" ].join(':')
+          ]
+        }
+        options['Privileged'] = true if Docker.version['Version'] >= '1.10.0'
+
+        publish(options)
       end
 
       def publish(options)

--- a/lib/conjur/fpm/Dockerfile
+++ b/lib/conjur/fpm/Dockerfile
@@ -5,7 +5,8 @@ RUN apt-get update -y && \
     apt-get dist-upgrade -y && \
     apt-get install -y build-essential \
                        git \
-                       libffi-dev 
+                       libffi-dev \
+                       rpm
 
 RUN gem install --no-document bundler:1.17.3 \
                               fpm

--- a/lib/conjur/fpm/package.sh
+++ b/lib/conjur/fpm/package.sh
@@ -40,10 +40,10 @@ else
     -n conjur-$project_name-dev \
     -v $version \
     -C . \
-    --maintainer "Conjur Inc." \
-    --vendor "Conjur Inc." \
+    --maintainer "CyberArk Software, Inc." \
+    --vendor "CyberArk Software, Inc." \
     --license "Proprietary" \
-    --url "https://www.conjur.net" \
+    --url "https://www.cyberark.com" \
     --deb-no-default-config-files \
     --$file_type-user conjur \
     --$file_type-group conjur \
@@ -77,10 +77,10 @@ do
   -n conjur-$project_name \
   -v $version \
   -C . \
-	--maintainer "Conjur Inc." \
-	--vendor "Conjur Inc." \
+	--maintainer "CyberArk Software, Inc." \
+	--vendor "CyberArk Software, Inc." \
 	--license "Proprietary" \
-	--url "https://www.conjur.net" \
+	--url "https://www.cyberark.com" \
 	--config-files opt/conjur/etc \
 	--deb-no-default-config-files \
 	--$file_type-user conjur \

--- a/spec/action/publish_spec.rb
+++ b/spec/action/publish_spec.rb
@@ -31,8 +31,8 @@ describe Conjur::Debify::Action::Publish do
     end
     
     it 'runs' do
-      expect(action).to receive(:publish)
-      
+      expect(action).to receive(:publish).twice
+
       action.run
     end
     
@@ -42,8 +42,8 @@ describe Conjur::Debify::Action::Publish do
 
     it 'runs' do
       expect(action).to receive(:fetch_art_creds)
-      expect(action).to receive(:publish)
-      
+      expect(action).to receive(:publish).twice
+
       action.run
     end
   end


### PR DESCRIPTION
Resolves conjurinc/AAM#319

We would like to offer the packages also to Linux-based machines that run RPM. Thus, we need to package and publish the components as RPM files in addition to debians.

Once this PR is merged, projects that will run `debify` will publish an RPM file to our redhat repo in artifactory.

An example can be seen in [this build of evoke](https://jenkins.conjur.net/blue/organizations/jenkins/conjurinc--evoke/detail/use-rpm-debify/6/pipeline/#step-39-log-221) that uses the `debify` docker image created by this side-branch.

**Note:** Every run of debify will package and publish also an RPM package. While this is needed for `conjur-ui`, `possum` and `evoke`, it is not needed for `conjur-ldap-sync` as that RPM will not be used in the dockerless image. So the artifcatory repo will have unused packages of `conjur-ldap-sync`.