### PR TITLE
Use dockerignore to Avoid Unwanted Files in Debian Packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - Debify now packages and publishes an RPM file, alongside a debian file.
   [conjurinc/debify#49](https://github.com/conjurinc/debify/pull/49)
 
+### Fixed
+- Bug causing `all` files in the git repo to be added to the debian file.
+  [conjurinc/debify#50](https://github.com/conjurinc/debify/pull/50)
+
 # 1.11.5
 
 ### Changed


### PR DESCRIPTION
Update image build process to use the Ruby Docker APIs dockerignore functionality. When we make the tar file ourselves [we skip over their code](https://github.com/swipely/docker-api/blob/1e9b9cc5f0f38dcd54c18189812328bb802d3656/lib/docker/image.rb#L292) that will take the dockerignore file into account. If we use [`build_from_dir`](https://github.com/swipely/docker-api/blob/1e9b9cc5f0f38dcd54c18189812328bb802d3656/lib/docker/image.rb#L289) to auto generate our tar from the dir of the project being debified, the dockerignore file will be taken into account when building the deb.

Additional Notes: https://github.com/conjurinc/ops/issues/606