### PR TITLE
Enable trivy "all issues" and update bundler to resolve 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /debify
 
 COPY . ./
 
+RUN gem install bundler:2.2.18
 RUN gem build debify.gemspec
 
 ARG VERSION

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,10 +42,14 @@ pipeline {
             scanAndReport("debify:${VERSION}", "HIGH", false)
           }
         }
-        // No all report generated because it currently adds 10-12 minutes of
-        // build time just to write the trivy report. It'll be added once we've
-        // cleaned up and/or ignored enough issues to reduce the impact
-        // on build time.
+        stage('Scan Docker image for all issues') {
+          steps{
+            script {
+              VERSION = sh(returnStdout: true, script: 'cat VERSION')
+            }
+            scanAndReport("debify:${VERSION}", "NONE", true)
+          }
+        }
       }
     }
 

--- a/debify.gemspec
+++ b/debify.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "conjur-cli" , "~> 6"
   spec.add_dependency "conjur-api", "~> 5"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", ">= 2.2.18"
   spec.add_development_dependency "fakefs", "~> 0"
   spec.add_development_dependency "rake", "~> 12.3.3"
   


### PR DESCRIPTION
A while ago the trivy all issues scan got turned off. I need it to run for stats tracking. Enough issues have been fixed that it no longer take 10+ minutes to write out the all issues scan results, so this PR re-enables that scan.

Additionally, bundler before 2.2.18 has issues where public versions of gems pulled from private repos can supersede the private versions. This PR also bumps bundler up to version 2.2.18 (like the rest of our repos) in order to protect against that possible attack. 