### PR TITLE
Bump phusion-ruby-fips image to latest

### DIFF
--- a/lib/conjur/fpm/Dockerfile
+++ b/lib/conjur/fpm/Dockerfile
@@ -1,5 +1,5 @@
 # Build from the same version of ubuntu as phusion/baseimage
-FROM cyberark/phusion-ruby-fips:0.11-latest
+FROM cyberark/phusion-ruby-fips:latest
 
 RUN apt-get update -y && \
     apt-get dist-upgrade -y && \


### PR DESCRIPTION
### Desired Outcome

Make debify to consume the most up to date base image.

### Implemented Changes

Tag of `phusion-ruby-fips` image has been changed from `0.11-latest` to `latests`.

### Connected Issue/Story

ONYX-11563

### Definition of Done

- [X] Debify consumes latest base image

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
