### PR TITLE
Delete deleteDir

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,6 @@ pipeline {
       steps {
         checkout scm
         sh './publish-rubygem.sh'
-        deleteDir()
       }
     }
   }


### PR DESCRIPTION
### Desired Outcome

Debify build is failing consistently since July.
It looks like there's a conflict between explicit `deleteDir()` call during the last build stage and `cleanupAndNotify` function.

### Implemented Changes

`deleteDir` has been deleted from Jenkinsfile

### Definition of Done

- [X] Build is green

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [X] There are no security aspects to these changes
