### PR TITLE
Ruby 3.0.2 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ features/reports
 *.so
 *.o
 *.a
+VERSION
 results.html
 mkmf.log
 *.deb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [3.0.0]
+### Changed
+
+- Upgrade ruby version to 3.0.
+- Bump `cucumber` gem to 7.1.
+- Bump `conjur-api` gem to 5.3.7.
+- Bump `conjur-cli` gem to 6.2.6.
+- Bump `aruba` gem to 2.0.
+- Bump `jfrog-cli` to :latest.
+
 ## [2.1.1]
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-stretch
+FROM ruby:3.0
 
 RUN apt-get update -qq && \
     apt-get dist-upgrade -qqy && \

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2020 CyberArk Software Ltd. All rights reserved.
+Copyright (c) 2022 CyberArk Software Ltd. All rights reserved.
 
 MIT License
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ gem install conjur-debify
 Pull the Docker image:
 
 ```sh-session
-$ VERSION=1.7.0
+$ VERSION=3.0.0
 $ docker pull registry.tld/conjurinc/debify:$VERSION
 ```
 
@@ -58,7 +58,7 @@ SYNOPSIS
     debify [global options] command [command options] [arguments...]
 
 VERSION
-    1.7.0
+    3.0.0
 
 
 GLOBAL OPTIONS

--- a/Rakefile
+++ b/Rakefile
@@ -33,14 +33,13 @@ if cucumber?
   Cucumber::Rake::Task.new(:features) do |t|
     opts = "features --format junit -o #{CUKE_RESULTS} --format pretty -x"
     opts += " --tags #{ENV['TAGS']}" if ENV['TAGS']
-    opts += " --tags ~@skip"
+    opts += " --tags 'not @skip'"
     t.cucumber_opts = opts
     t.fork = false
   end
 
   desc 'Run features tagged as work-in-progress (@wip)'
   Cucumber::Rake::Task.new('features:wip') do |t|
-    tag_opts = ' --tags ~@pending'
     tag_opts = ' --tags @wip'
     t.cucumber_opts = "features --format junit -o #{CUKE_RESULTS} --format pretty -x -s#{tag_opts}"
     t.fork = false

--- a/Rakefile
+++ b/Rakefile
@@ -31,17 +31,35 @@ if cucumber?
 
   desc 'Run features'
   Cucumber::Rake::Task.new(:features) do |t|
-    opts = "features --format junit -o #{CUKE_RESULTS} --format pretty -x"
-    opts += " --tags #{ENV['TAGS']}" if ENV['TAGS']
-    opts += " --tags 'not @skip'"
+    opts = [
+      "features",
+      "--format",
+      "junit",
+      "-o",
+      CUKE_RESULTS,
+      "--format",
+      "pretty",
+      "-x"]
+    opts += ["--tags", ENV['TAGS']] if ENV['TAGS']
+    opts += ["--tags", "not @skip"]
     t.cucumber_opts = opts
     t.fork = false
   end
 
   desc 'Run features tagged as work-in-progress (@wip)'
   Cucumber::Rake::Task.new('features:wip') do |t|
-    tag_opts = ' --tags @wip'
-    t.cucumber_opts = "features --format junit -o #{CUKE_RESULTS} --format pretty -x -s#{tag_opts}"
+    tag_opts = %w[--tags @wip]
+    opts = [
+      "features",
+      "--format",
+      "junit",
+      "-o",
+      CUKE_RESULTS,
+      "--format",
+      "pretty",
+      "-x",
+      "-s"]
+    t.cucumber_opts = opts + tag_opts
     t.fork = false
   end
 

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,8 @@
 #!/bin/bash -ex
 
+if [ ! -f "VERSION" ]; then
+  echo -n "0.0.1.dev" > VERSION
+fi
+
 VERSION=$(< VERSION)
 docker build --build-arg VERSION=$VERSION -t debify:$VERSION .

--- a/debify.gemspec
+++ b/debify.gemspec
@@ -20,8 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "gli"
   spec.add_dependency "docker-api", "~> 2.0"
   spec.add_dependency "conjur-cli" , "~> 6"
-  spec.add_dependency "conjur-api", "~> 5"
-
+  spec.add_dependency "conjur-api", "~> 5.3"
   spec.add_development_dependency "bundler", ">= 2.2.30"
   spec.add_development_dependency "fakefs", "~> 0"
   spec.add_development_dependency "rake", "~> 13.0"
@@ -30,8 +29,8 @@ Gem::Specification.new do |spec|
   # unmatched capture groups with \(d+). In v3, the value of such a
   # group is 0 instead of nil, which breaks aruba's "I successfully
   # run...." steps.
-  spec.add_development_dependency "cucumber", '~> 2'
-  spec.add_development_dependency "aruba", "~> 1.0"
-  spec.add_development_dependency 'rspec', '~> 3'
+  spec.add_development_dependency "cucumber", '~> 7.1'
+  spec.add_development_dependency "aruba", "~> 2.0"
+  spec.add_development_dependency 'rspec', '~> 3.10'
   spec.add_development_dependency 'ci_reporter_rspec', '~> 1.0'
 end

--- a/features/detect_version.feature
+++ b/features/detect_version.feature
@@ -1,7 +1,12 @@
+@announce-output
 Feature: Automatic version string
 
-  @announce-output
   Scenario: 'example' project gets a default version
     When I run `env DEBUG=true GLI_DEBUG=true debify detect-version -d ../../example`
     Then the exit status should be 0
     And the output should match /\d+.\d+.\d+-\d+-.*/
+
+  @skip
+  Scenario: Test @skip tag, failed by default
+    When I run `env DEBUG=true GLI_DEBUG=true debify detect-version -d ../../example`
+    Then the exit status should be 1

--- a/lib/conjur/publish/Dockerfile
+++ b/lib/conjur/publish/Dockerfile
@@ -1,4 +1,4 @@
-FROM releases-docker.jfrog.io/jfrog/jfrog-cli:1.52.0
+FROM releases-docker.jfrog.io/jfrog/jfrog-cli:latest
 
 ENV JFROG_CLI_OFFER_CONFIG=false
 


### PR DESCRIPTION
### Desired Outcome

As part of Conjur upgrade to Ruby 3, all related repositories are upgraded.
Debify upgrade consists of updating the base images and gems to those that support ruby 3.
New major debify 3.0.0 version will be released after this PR.
Thus, all other repositories that are transitioning to Ruby 3 and consume debify will work with V3.0.0. 

### Implemented Changes

* Updated docker base to use Ruby 3
* Updated outdated gems to work with ruby 3
* Base image update is automatic since its always consuming :latest (conjur-base-image repo also upgraded to Ruby 3)

### Connected Issue/Story

Resolves Internal Cyberark issue [ONYX-10408](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-10408)
Ruby 3 Upgrade Epic link: [ONYX-9661](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-9661)

### Definition of Done

Debify runs on top of ruby 3, all tests are green.

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
