### PR TITLE
Base publish image on JFrog CLI Image

### DIFF
--- a/lib/conjur/publish/Dockerfile
+++ b/lib/conjur/publish/Dockerfile
@@ -1,11 +1,5 @@
-FROM buildpack-deps:curl
+FROM releases-docker.jfrog.io/jfrog/jfrog-cli:1.52.0
 
 ENV JFROG_CLI_OFFER_CONFIG=false
-ENV JFROG_VERSION=1.13.1
-
-RUN curl -kL \
-    -o /usr/bin/jfrog \
-    https://bintray.com/jfrog/jfrog-cli-go/download_file?file_path=${JFROG_VERSION}%2Fjfrog-cli-linux-amd64%2Fjfrog && \
-    chmod +x /usr/bin/jfrog
 
 WORKDIR /src


### PR DESCRIPTION
This resolves two issues:
1) The version of the CLI we currently attempt to download is no
   longer available

2) Certificate validation is disabled when downloading the CLI,
   leaving the process open to a possible MITM attack.

Related: conjurinc/ops#841