### PR TITLE
Update to use release-tools publish-rubygem

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,6 +102,7 @@ pipeline {
       steps {
         release {
           sh './publish-rubygem.sh'
+          sh 'cp debify-*.gem release-assets/.'
         }
       }
     }

--- a/publish-rubygem.sh
+++ b/publish-rubygem.sh
@@ -1,6 +1,5 @@
-#!/bin/bash -e
-
-docker pull registry.tld/conjurinc/publish-rubygem
+#!/usr/bin/env bash
+set -e
 
 docker run -i --rm -v $PWD:/src -w /src alpine/git clean -fxd \
   -e VERSION \
@@ -8,5 +7,4 @@ docker run -i --rm -v $PWD:/src -w /src alpine/git clean -fxd \
   -e release-assets/
 
 summon --yaml "RUBYGEMS_API_KEY: !var rubygems/api-key" \
-  docker run --rm --env-file @SUMMONENVFILE -v "$(pwd)":/opt/src \
-  registry.tld/conjurinc/publish-rubygem debify
+  publish-rubygem debify


### PR DESCRIPTION
This moves away from the publish-rubygem container to use the
release-tools provided publish-rubygem. This allows the gem file
to be archived along with the release rather than just on rubygems.org

Release builds will fail until conjurinc/release-tools#17 has been merged.