### PR TITLE
Change VERSION read for image tags

### DIFF
--- a/image-tags
+++ b/image-tags
@@ -3,7 +3,7 @@
 : ${BRANCH_NAME:=$(git symbolic-ref --short HEAD)}
 
 show_master_tags() {
-  IFS=. read MAJOR MINOR PATCH <VERSION
+  IFS=. read MAJOR MINOR PATCH <<< "$(<VERSION)"
   TAG="$MAJOR.$MINOR.$PATCH"
   echo "latest $TAG $MAJOR.$MINOR"
 }


### PR DESCRIPTION
The version of bash on the Jenkins executors causes the previous
route of reading the version to terminate early on master branch
builds because of reaching EOF on the VERSION file during the read
command.  This fixes the issue and allows images to be pushed.

It is unknown how long this was broken for