### PR TITLE
Include project-name as name of container for tests

### DIFF
--- a/lib/conjur/debify.rb
+++ b/lib/conjur/debify.rb
@@ -540,6 +540,7 @@ RUN touch /etc/service/conjur/down
       FileUtils.mkdir_p dot_bundle_dir
       options = {
         'Image' => appliance_image.id,
+        'name' => project_name,
         'Env' => [
           "CONJUR_AUTHN_LOGIN=admin",
           "CONJUR_ENV=appliance",


### PR DESCRIPTION
Add a name to the container under test from the supplied project-name so other necessary containers can reach it.