### PR TITLE
Supply debian distribution to fpm

### DIFF
--- a/lib/conjur/fpm/package.sh
+++ b/lib/conjur/fpm/package.sh
@@ -64,6 +64,7 @@ else
     --license "Proprietary" \
     --url "https://www.cyberark.com" \
     --deb-no-default-config-files \
+    --deb-dist "whatever" \
     --$file_type-user conjur \
     --$file_type-group conjur \
     --depends "conjur-$project_name = $version" \
@@ -99,6 +100,7 @@ fpm \
   --url "https://www.cyberark.com" \
   --config-files opt/conjur/etc \
   --deb-no-default-config-files \
+  --deb-dist "whatever" \
   --$file_type-user conjur \
   --$file_type-group conjur \
   --description "Conjur $project_name service" \


### PR DESCRIPTION
### Background ###

In jordansissel/fpm@37f56269c331c47758d0010e335f9d12d3094574 the default distribution was changed from whatever to null.

When debian packages are promoted (from release to customer release) the package is expanded, then the version is changed and its repacked. This failed for conjur-ui because the included changelog was deemed invalid by the re-package process. The reason for is the lack of distribution field.

In future we can set this to something more useful if it becomes necessary.

### Desired Outcome

All packages build by debify have a valid changelog

### Implemented Changes

In older packages the distribution field was hardcoded to 'whatever' by fpm. This commit brings back 'whatever' as the default.

### Connected Issue/Story

CyberArk internal issue ID:  ONYX-29717
