### PR TITLE
Mark the working directory as git safe for docker-debify

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-git config --global --add safe.directory $PWD
+git config --global --add safe.directory "$PWD"
 
 bundle
 

--- a/distrib/entrypoint.sh
+++ b/distrib/entrypoint.sh
@@ -15,5 +15,9 @@ if [[ ${#creds[*]} > 0 ]]; then
   echo -n "${creds[1]}" | docker login registry.tld -u ${creds[0]} --password-stdin >/dev/null 2>&1
 fi
 
+# Ensure the current working directory is considered safe by git in the debify
+# container.
+git config --global --add safe.directory "$PWD"
+
 exec debify "$@"
 


### PR DESCRIPTION
### Desired Outcome

The desired outcome of this PR is to allow debify to build our projects successfully in their git repos. Namely to fix the builds for:
- https://github.com/conjurinc/ldap-sync/pull/239
- https://github.com/conjurinc/conjur-ui/pull/646

### Implemented Changes

This PR marks the working directory in the `docker-debify` container as safe in git, so that the files in a projects repo may be used for Docker builds within the `docker-debify` container.

### Connected Issue/Story

Connected to: #83 

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
