### PR TITLE
allow base image to be configured on execution, update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.0.2]
+### Changed
+- Allow Base Image to be configured on execution.
+- Updated dependencies.
+- Adapted code to reflect Docker API changes, specifying at least one stream is now required.
+  [conjurinc/debify#86](https://github.com/conjurinc/debify/issues/86)
+
 ## [3.0.1]
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -254,11 +254,11 @@ root@7d4217655332:/src/authz# bundle exec rake db:migrate
 
 ## Usage with docker-compose
 
-As of v1.10.0, both the `test` and `sandbox` subcommands support the `--net` switch. This allows you to specify a network to which the Conjur appliance container should be attached.
+As of v1.10.0, both the `test` and `sandbox` subcommands support the `--net` switch.
+This allows you to specify a network to which the Conjur appliance container should be attached.
 
-There are a variety of ways to make use of this feature. One
-possiblity is creating a network using `docker network create`, then
-attaching both the docker-compose services, as well as the Conjur
+There are a variety of ways to make use of this feature. One possibility is creating a network
+using `docker network create`, then attaching both the docker-compose services, as well, as the Conjur
 appliance container created by debify, to it.
 
 As a (somewhat contrived) example, create a new docker network:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Builds a Conjur Debian package from a Ruby gem.
 $ debify help package
 NAME
     package - Build a debian package for a project
-    
+
 SYNOPSIS
     debify [global options] package [command options] project_name -- <fpm-arguments>
 b
@@ -110,11 +110,16 @@ DESCRIPTION
     The distrib folder in the project source tree is intended to create scripts for package pre-install, post-install etc. The distrib folder is not
     included in the deb package, so its contents should be copied to the file system or packaged using fpm arguments.
 
-    All arguments to this command which follow the double-dash are propagated to the fpm command. 
+    All arguments to this command which follow the double-dash are propagated to the fpm command.
 
 COMMAND OPTIONS
-    -d, --dir=arg     - Set the current working directory (default: none)
-    -v, --version=arg - Specify the deb version; by default, it's read from the VERSION file (default: none)
+    --additional-files=arg - Specify files to add to the FPM image that are not included from the git repo (default: none)
+    -d, --dir=arg          - Set the current working directory (default: none)
+    --dockerfile=arg       - Specify a custom Dockerfile.fpm (default: none)
+    -i, --image=arg        - Image name (default: cyberark/phusion-ruby-fips)
+    -o, --output=arg       - Set the output file type of the fpm command (e.g rpm) (default: none)
+    -t, --image-tag=arg    - Image tag, e.g. 4.5-stable, 4.6-stable (default: latest)
+    -v, --version=arg      - Specify the deb version; by default, it's read from the VERSION file (default: none)
 ```
 
 ### Example usage
@@ -151,7 +156,7 @@ DESCRIPTION
 
     Finally, a test script from the project source tree is run, again with the container id as the program argument.
 
-    Then the Conjur container is deleted (use --keep to leave it running). 
+    Then the Conjur container is deleted (use --keep to leave it running).
 
 COMMAND OPTIONS
     -c, --configure-script=arg - Shell script to configure the appliance before testing (default: none)
@@ -215,17 +220,17 @@ NAME
     sandbox - Setup a development sandbox for a Conjur debian package in a Conjur appliance container
 
 SYNOPSIS
-    debify [global options] sandbox [command options] 
+    debify [global options] sandbox [command options]
 
 DESCRIPTION
-    First, a Conjur appliance container is created and started. By default, the container image is 
+    First, a Conjur appliance container is created and started. By default, the container image is
     registry.tld/conjur-appliance-cuke-master. An image tag MUST be supplied. This image
-    is configured with all the CONJUR_ environment variables setup for the local environment (appliance URL, 
+    is configured with all the CONJUR_ environment variables setup for the local environment (appliance URL,
     cert path, admin username and password, etc). The project source tree is
-    also mounted into the container, at /src/<project-name>, where <project-name> is taken from the name of the 
+    also mounted into the container, at /src/<project-name>, where <project-name> is taken from the name of the
     current working directory.
 
-    Once in the container, use "/opt/conjur/evoke/bin/dev-install" to install the development bundle of your project. 
+    Once in the container, use "/opt/conjur/evoke/bin/dev-install" to install the development bundle of your project.
 
 COMMAND OPTIONS
     --bind=arg          - Bind another source directory into the container. Use <src>:<dest>, where both are full paths. (default: none)
@@ -249,12 +254,12 @@ root@7d4217655332:/src/authz# bundle exec rake db:migrate
 
 ## Usage with docker-compose
 
-As of v1.10.0, both the `test` and `sandbox` subcommands support the `--net` switch. This allows you to specify a network to which the Conjur appliance container should be attached. 
+As of v1.10.0, both the `test` and `sandbox` subcommands support the `--net` switch. This allows you to specify a network to which the Conjur appliance container should be attached.
 
 There are a variety of ways to make use of this feature. One
 possiblity is creating a network using `docker network create`, then
 attaching both the docker-compose services, as well as the Conjur
-appliance container created by debify, to it. 
+appliance container created by debify, to it.
 
 As a (somewhat contrived) example, create a new docker network:
 
@@ -298,6 +303,6 @@ root@7d4217655332:/src/example# getent hosts mydb
 
 ## Contributing
 
-For instructions on how to get started and 
+For instructions on how to get started and
 descriptions of our development workflows, please see our
 [contributing guide](CONTRIBUTING.md).

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,9 +2,8 @@
 
 git config --global --add safe.directory "$PWD"
 
-bundle
+bundle install
 
 for target in spec cucumber; do
   bundle exec rake $target
 done
-

--- a/debify.gemspec
+++ b/debify.gemspec
@@ -16,21 +16,21 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  
+
   spec.add_dependency "gli"
   spec.add_dependency "docker-api", "~> 2.0"
   spec.add_dependency "conjur-cli" , "~> 6"
   spec.add_dependency "conjur-api", "~> 5.3"
-  spec.add_development_dependency "bundler", ">= 2.2.33"
-  spec.add_development_dependency "fakefs", "~> 0"
+  spec.add_development_dependency "bundler", ">= 2.4.14"
+  spec.add_development_dependency "fakefs", "~> 2.5.0"
   spec.add_development_dependency "rake", "~> 13.0"
-  
+
   # Pin to cucumbe v2. cucumber v3 changes (breaks) the behavior of
   # unmatched capture groups with \(d+). In v3, the value of such a
   # group is 0 instead of nil, which breaks aruba's "I successfully
   # run...." steps.
   spec.add_development_dependency "cucumber", '~> 7.1'
-  spec.add_development_dependency "aruba", "~> 2.0"
-  spec.add_development_dependency 'rspec', '~> 3.10'
+  spec.add_development_dependency "aruba", "~> 2.1"
+  spec.add_development_dependency 'rspec', '~> 3.12'
   spec.add_development_dependency 'ci_reporter_rspec', '~> 1.0'
 end

--- a/lib/conjur/debify.rb
+++ b/lib/conjur/debify.rb
@@ -379,7 +379,7 @@ end
 def wait_for_conjur appliance_image, container
   container_command container, '/opt/conjur/evoke/bin/wait_for_conjur'
 rescue
-  $stderr.puts container.logs
+  $stderr.puts container.logs(stdout: true, stderr: true)
   raise
 end
 

--- a/lib/conjur/debify.rb
+++ b/lib/conjur/debify.rb
@@ -78,7 +78,7 @@ subcommand_option_handling :normal
 arguments :strict
 
 def detect_version
-  if File.exists?("VERSION") && !(base_commit = `git log --pretty='%h' VERSION | head -n 1`.strip).empty?
+  if File.exist?("VERSION") && !(base_commit = `git log --pretty='%h' VERSION | head -n 1`.strip).empty?
     base_version = File.read("VERSION").strip
     commits_since = `git log #{base_commit}..HEAD --pretty='%h'`.split("\n").size
     hash = `git rev-parse --short HEAD`.strip
@@ -254,6 +254,14 @@ command "package" do |c|
   c.desc "Specify files to add to the FPM image that are not included from the git repo"
   c.flag [:'additional-files']
 
+  c.desc "Image name"
+  c.default_value "cyberark/phusion-ruby-fips"
+  c.flag [:i, :image]
+
+  c.desc "Image tag, e.g. 4.5-stable, 4.6-stable"
+  c.default_value "latest"
+  c.flag [:t, :'image-tag']
+
   c.action do |global_options, cmd_options, args|
     raise "project-name is required" unless project_name = args.shift
 
@@ -272,9 +280,13 @@ command "package" do |c|
       additional_files = cmd_options[:'additional-files'].split(',').map(&:strip)
     end
 
+    dockerfile = File.read(File.expand_path('fpm/Dockerfile.template', File.dirname(__FILE__)))
+    replace_image = dockerfile.gsub("@@image@@", cmd_options[:'image'] + ":" + cmd_options[:'image-tag'])
+    File.open(File.expand_path('fpm/Dockerfile', File.dirname(__FILE__)), "w") { |file| file.puts replace_image }
+
     begin
       tries ||= 2
-      fpm_image = Docker::Image.build_from_dir File.expand_path('fpm', File.dirname(__FILE__)), tag: "debify-fpm", &DebugMixin::DOCKER
+      fpm_image = Docker::Image.build_from_dir File.expand_path('fpm', File.dirname(__FILE__)), architecture: "x86_64", tag: "debify-fpm", &DebugMixin::DOCKER
     rescue
       image_id = File.readlines(File.expand_path('fpm/Dockerfile', File.dirname(__FILE__)))
                      .find { | line | line =~ /^FROM/ }
@@ -848,4 +860,3 @@ on_error do |exception|
   # return false to skip default error handling
   true
 end
-

--- a/lib/conjur/fpm/Dockerfile.template
+++ b/lib/conjur/fpm/Dockerfile.template
@@ -1,5 +1,4 @@
-# Build from the same version of ubuntu as phusion/baseimage
-FROM cyberark/phusion-ruby-fips:latest
+FROM @@image@@
 
 RUN apt-get update -y && \
     apt-get dist-upgrade -y && \


### PR DESCRIPTION
### Desired Outcome

Allow to configure the base image that is used in the debify to allow introducing of major OS or ruby version changes.

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
