### PR TITLE
Add .trivyignore entry for CVE-2017-14033

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,5 @@
+# Scanners have started flagging CVE-2017-14033 because they are matching 
+# the version of Ruby that shipped the vulnerable openssl gem with the 
+# version of openssl itself. We use Ruby 3 in our base images, so already
+# have the fix for this issue.
+CVE-2017-14033


### PR DESCRIPTION
### Desired Outcome

Ignore CVE-2017-14033 as we have the fix already (trivy is currently comparing the version of Ruby that shipped the openssl gem to the version of the gem itself).