### PR TITLE
Fix regressions in linting fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 - Allow user to specify architecture of packages (arm64 or amd64)
 - Upload artifacts for all packaged architectures to artifactory
 
+### Fixed
+- Fixed regressions introduced by incorrect linting fixes. Most significantly,
+  preventing the `VERSION` file from being included in release packages.
+
 ## [3.0.2]
 ### Changed
 - Allow Base Image to be configured on execution.
@@ -40,11 +44,11 @@
 
 - Refine bundler related steps in `debify package` flow: only `package.sh` file configures
   and invokes bundler. `Dockerfile.fpm` only copies files and adjusts folder structure.
-- Remove bundler 1.* support 
+- Remove bundler 1.* support
 
 # 2.0.0
 ### Changed
-- Debify now receives the flag `--output` as input to indicate the file type that it should package (e.g `rpm`). If this 
+- Debify now receives the flag `--output` as input to indicate the file type that it should package (e.g `rpm`). If this
   flag is not given, the default value is `deb`.
   [conjurinc/debify#56](https://github.com/conjurinc/debify/issues/56)
 

--- a/lib/conjur/debify.rb
+++ b/lib/conjur/debify.rb
@@ -93,7 +93,7 @@ def detect_version
 end
 
 def git_files
-  files = (`git ls-files -z`.split("\x0") + %w['Gemfile.lock', 'VERSION']).uniq
+  files = (`git ls-files -z`.split("\x0") + %w[Gemfile.lock VERSION]).uniq
   # Since submodule directories are listed, but are not files, we remove them.
   # Currently, `conjur-project-config` is the only submodule in Conjur, and it
   # can safely be removed because it's a developer-only tool.  If we add another
@@ -154,7 +154,7 @@ command "clean" do |c|
     unless perform_deletion
       $stderr.puts "No --force, and this doesn't look like Jenkins. I won't actually delete anything"
     end
-    @ignore_list = Array(cmd_options[:ignore]) + %w['.', '..', '.git']
+    @ignore_list = Array(cmd_options[:ignore]) + %w[. .. .git]
 
     def ignore_file?(f)
       @ignore_list.find { |ignore| f.index(ignore) == 0 }
@@ -584,10 +584,10 @@ RUN touch /etc/service/conjur/down
         'Image' => appliance_image.id,
         'name' => project_name,
         'Env' => %w[
-          "CONJUR_AUTHN_LOGIN=admin",
-          "CONJUR_ENV=appliance",
-          "CONJUR_AUTHN_API_KEY=SEcret12!!!!",
-          "CONJUR_ADMIN_PASSWORD=SEcret12!!!!",
+          CONJUR_AUTHN_LOGIN=admin
+          CONJUR_ENV=appliance
+          CONJUR_AUTHN_API_KEY=SEcret12!!!!
+          CONJUR_ADMIN_PASSWORD=SEcret12!!!!
         ] + global_options[:env],
         'HostConfig' => {
           'Binds' => [
@@ -734,10 +734,10 @@ command "sandbox" do |c|
         'Image' => appliance_image.id,
         'WorkingDir' => "/src/#{project_name}",
         'Env' => %w[
-          "CONJUR_AUTHN_LOGIN=admin",
-          "CONJUR_ENV=appliance",
-          "CONJUR_AUTHN_API_KEY=SEcret12!!!!",
-          "CONJUR_ADMIN_PASSWORD=SEcret12!!!!",
+          CONJUR_AUTHN_LOGIN=admin
+          CONJUR_ENV=appliance
+          CONJUR_AUTHN_API_KEY=SEcret12!!!!
+          CONJUR_ADMIN_PASSWORD=SEcret12!!!!
         ] + global_options[:env]
       }
 


### PR DESCRIPTION
This PR fixes regressions made to the debify code while fixing linting issues.

These arrays were previously converted to the %w[] syntax in a prior PR, however the quotes and commas were not removed at the same time, leading the array contents to be different after the change.

Prior PR:
https://github.com/conjurinc/debify/pull/89

