### PR TITLE
Allow AMD64 agent to build ARM-based image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [3.0.3]
 ### Added
-- Allow user to specify architecture of packages (arm64 or amd64)
+- Build ARM64 image using platform parameter
 - Upload artifacts for all packaged architectures to artifactory
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -110,10 +110,9 @@ DESCRIPTION
     The distrib folder in the project source tree is intended to create scripts for package pre-install, post-install etc. The distrib folder is not
     included in the deb package, so its contents should be copied to the file system or packaged using fpm arguments.
 
-    All arguments to this command which follow the double-dash are propagated to the fpm command. 
+    All arguments to this command which follow the double-dash are propagated to the fpm command.
 
 COMMAND OPTIONS
-    -a, --architecture=arg - Set the architecture of the package; can be set to arm64 or amd64 (default: amd64)
     --additional-files=arg - Specify files to add to the FPM image that are not included from the git repo (default: none)
     -d, --dir=arg          - Set the current working directory (default: none)
     --dockerfile=arg       - Specify a custom Dockerfile.fpm (default: none)

--- a/build.sh
+++ b/build.sh
@@ -5,4 +5,10 @@ if [ ! -f "VERSION" ]; then
 fi
 
 VERSION=$(< VERSION)
-docker build --build-arg VERSION=$VERSION -t debify:$VERSION .
+
+ARCH="$1"
+if [ -z "$ARCH" ]; then
+  ARCH="amd64"
+fi
+
+docker build --platform "linux/$ARCH" --build-arg VERSION=$VERSION -t debify:$VERSION-$ARCH .

--- a/features/package.feature
+++ b/features/package.feature
@@ -4,48 +4,20 @@ Feature: Packaging
   Background:
     # We use version 0.0.1-suffix to verify that RPM converts dashes to underscores
     # in the version as we expect
-
-
-  Scenario: 'example' project can be packaged successfully for amd64
-    Given I successfully run `env DEBUG=true GLI_DEBUG=true debify package -d ../../example -v 0.0.1-suffix --architecture=amd64 example -- --post-install /distrib/postinstall.sh`
-    And I successfully run `env DEBUG=true GLI_DEBUG=true debify package -d ../../example --output rpm  -v 0.0.1-suffix --architecture=amd64 example  -- --post-install /distrib/postinstall.sh`
-    Then the stdout should contain "conjur-example_0.0.1-suffix_amd64.deb"
-    And the stdout should contain "conjur-example-dev_0.0.1-suffix_amd64.deb"
-    And the stdout should contain "conjur-example-0.0.1_suffix-1.x86_64.rpm"
-    And the stdout should contain "conjur-example-dev-0.0.1_suffix-1.x86_64.rpm"
-
-  Scenario: 'clean' command will delete non-Git-managed files for amd64
-    Given I successfully run `env DEBUG=true GLI_DEBUG=true debify package -d ../../example -v 0.0.1-suffix --architecture=amd64 example -- --post-install /distrib/postinstall.sh`
-    And I successfully run `env DEBUG=true GLI_DEBUG=true debify package -d ../../example --output rpm  -v 0.0.1-suffix --architecture=amd64 example  -- --post-install /distrib/postinstall.sh`
-    When I successfully run `env DEBUG=true GLI_DEBUG=true debify clean -d ../../example --force`
-    And I successfully run `find ../../example`
-    Then the stdout from "find ../../example" should not contain "conjur-example_0.0.1-suffix_amd64.deb"
-    And the stdout from "find ../../example" should not contain "conjur-example-0.0.1_suffix-1.x86_64.rpm"
-
-  Scenario: 'example' project can be packaged successfully for arm64
-    Given I successfully run `env DEBUG=true GLI_DEBUG=true debify package -d ../../example -v 0.0.1-suffix --architecture=aarch64 example -- --post-install /distrib/postinstall.sh`
-    And I successfully run `env DEBUG=true GLI_DEBUG=true debify package -d ../../example --output rpm  -v 0.0.1-suffix --architecture=aarch64 example  -- --post-install /distrib/postinstall.sh`
-    Then the stdout should contain "conjur-example_0.0.1-suffix_arm64.deb"
-    And the stdout should contain "conjur-example-dev_0.0.1-suffix_arm64.deb"
-    And the stdout should contain "conjur-example-0.0.1_suffix-1.aarch64.rpm"
-    And the stdout should contain "conjur-example-dev-0.0.1_suffix-1.aarch64.rpm"
-
-  Scenario: 'clean' command will delete non-Git-managed files for arm64
-    Given I successfully run `env DEBUG=true GLI_DEBUG=true debify package -d ../../example -v 0.0.1-suffix --architecture=aarch64 example -- --post-install /distrib/postinstall.sh`
-    And I successfully run `env DEBUG=true GLI_DEBUG=true debify package -d ../../example --output rpm  -v 0.0.1-suffix --architecture=aarch64 example  -- --post-install /distrib/postinstall.sh`
-    When I successfully run `env DEBUG=true GLI_DEBUG=true debify clean -d ../../example --force`
-    And I successfully run `find ../../example`
-    Then the stdout from "find ../../example" should not contain "conjur-example_0.0.1-suffix_arm64.deb"
-    And the stdout from "find ../../example" should not contain "conjur-example-0.0.1_suffix-1.aarch64.rpm"
-
-  Scenario: 'example' project can be published with amd64 architecture
     Given I successfully run `env DEBUG=true GLI_DEBUG=true debify package -d ../../example -v 0.0.1-suffix example -- --post-install /distrib/postinstall.sh`
     And I successfully run `env DEBUG=true GLI_DEBUG=true debify package -d ../../example --output rpm  -v 0.0.1-suffix example  -- --post-install /distrib/postinstall.sh`
-    When I successfully run `env DEBUG=true GLI_DEBUG=true debify publish -v 0.0.1-suffix -d ../../example 5.0 example`
 
-#  Scenario: 'example' project can be published with amd64 and arm64 architectures
-    Given I successfully run `env DEBUG=true GLI_DEBUG=true debify package -d ../../example -v 0.0.1-suffix example -- --post-install /distrib/postinstall.sh`
-    And I successfully run `env DEBUG=true GLI_DEBUG=true debify package -d ../../example --architecture="aarch64" -v 0.0.1-suffix example -- --post-install /distrib/postinstall.sh`
-    And I successfully run `env DEBUG=true GLI_DEBUG=true debify package -d ../../example --output rpm  -v 0.0.1-suffix example  -- --post-install /distrib/postinstall.sh`
-    And I successfully run `env DEBUG=true GLI_DEBUG=true debify package -d ../../example --output rpm --architecture="aarch64"  -v 0.0.1-suffix example  -- --post-install /distrib/postinstall.sh`
+  Scenario: 'example' project can be packaged successfully
+    Then the output should match /conjur-example_0\.0\.1-suffix_(amd64|arm64)\.deb/
+    And the output should match /conjur-example-dev_0\.0\.1-suffix_(amd64|arm64)\.deb/
+    And the output should match /conjur-example-0\.0\.1_suffix-1\.(x86_64|aarch64)\.rpm/
+    And the output should match /conjur-example-dev-0\.0\.1_suffix-1\.(x86_64|aarch64)\.rpm/
+
+  Scenario: 'clean' command will delete non-Git-managed files
+    When I successfully run `env DEBUG=true GLI_DEBUG=true debify clean -d ../../example --force`
+    And I cd to "../../example"
+    Then a file matching %r</conjur-example_0\.0\.1-suffix_(amd64|arm64)\.deb/> should not exist
+    And a file matching %r</conjur-example-0\.0\.1_suffix-1\.(x86_64|aarch64)\.rpm/> should not exist
+
+  Scenario: 'example' project can be published
     When I successfully run `env DEBUG=true GLI_DEBUG=true debify publish -v 0.0.1-suffix -d ../../example 5.0 example`

--- a/lib/conjur/fpm/package.sh
+++ b/lib/conjur/fpm/package.sh
@@ -22,10 +22,6 @@ for i in "$@"; do
     file_type="${i#*=}"
     shift
     ;;
-  --architecture=*)
-    architecture="${i#*=}"
-    shift
-    ;;
   esac
 done
 
@@ -34,15 +30,9 @@ if [ -z "$file_type" ]; then
   file_type=deb
 fi
 
-if [ -z "$architecture" ]; then
-  echo "No architecture given. Using amd64"
-  file_type=amd64
-fi
-
 echo Project Name is $project_name
 echo Version is $version
 echo file_type is $file_type
-echo architecture is $architecture
 echo params at the end are $@
 
 # Build dev package first
@@ -66,7 +56,6 @@ else
   fpm \
     -s dir \
     -t $file_type \
-    -a $architecture \
     -n conjur-$project_name-dev \
     -v $version \
     -C . \
@@ -102,7 +91,6 @@ echo "Building conjur-$project_name $file_type package"
 fpm \
   -s dir \
   -t $file_type \
-  -a $architecture \
   -n conjur-$project_name \
   -v $version \
   -C . \

--- a/push-image.sh
+++ b/push-image.sh
@@ -1,6 +1,12 @@
 #!/bin/bash -ex
 
-for t in $(./image-tags); do
-  docker push registry.tld/conjurinc/debify:$t
-done
+TAG=$(< VERSION)
+ARCH="$1"
+if [ -z "$ARCH" ]; then
+  ARCH="amd64"
+fi
 
+for t in $(./image-tags); do
+  docker tag "debify:$TAG-$ARCH" "registry.tld/conjurinc/debify:$t-$ARCH"
+  docker push "registry.tld/conjurinc/debify:$t-$ARCH"
+done

--- a/push-manifest.sh
+++ b/push-manifest.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -ex
+
+for t in $(./image-tags); do
+  docker pull "registry.tld/conjurinc/debify:$t-amd64"
+  docker pull "registry.tld/conjurinc/debify:$t-arm64"
+
+  docker manifest create \
+    --insecure \
+    "registry.tld/conjurinc/debify:$t" \
+    --amend "registry.tld/conjurinc/debify:$t-amd64" \
+    --amend "registry.tld/conjurinc/debify:$t-arm64"
+
+  docker manifest push --insecure "registry.tld/conjurinc/debify:$t"
+done

--- a/tag-image.sh
+++ b/tag-image.sh
@@ -1,6 +1,0 @@
-#!/bin/bash -ex
-
-TAG=$(< VERSION)
-for t in $(./image-tags); do
-  docker tag debify:$TAG registry.tld/conjurinc/debify:$t
-done

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,12 @@
 #!/bin/bash -ex
 
 VERSION=$(< VERSION)
-docker run --rm debify:$VERSION config script > docker-debify
+
+ARCH="$1"
+if [ -z "$ARCH" ]; then
+  ARCH="amd64"
+fi
+
+docker run --rm "debify:$VERSION-$ARCH" config script > docker-debify
 chmod +x docker-debify
-DEBIFY_IMAGE=debify:$VERSION DEBIFY_ENTRYPOINT=ci/test.sh ./docker-debify
+DEBIFY_IMAGE=debify:$VERSION-$ARCH DEBIFY_ENTRYPOINT=ci/test.sh ./docker-debify


### PR DESCRIPTION
### Desired Outcome

*Goal of this PR is to allow to build native ARM64 debify image to be used later on in system like Conjur, conjur-ui or ldap-sync to package DEB or RPM.*

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*

- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
